### PR TITLE
Use label parameter when constructing elements.Select

### DIFF
--- a/prompt/multi-select.go
+++ b/prompt/multi-select.go
@@ -6,7 +6,7 @@ import "github.com/josa42/go-prompt/elements"
 func MultiSelect(label string, options Options) (selection []string, canceled bool) {
 
 	menu := elements.Select{
-		Label: "Select options",
+		Label: label,
 		Multi: true,
 	}
 


### PR DESCRIPTION
I've seen that the multi-select does not use the label parameter of the method and fixed that.

Nice library you've build here :+1: 